### PR TITLE
Support external initialization and abstract `item`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,8 @@
     "purescript-record": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-debug": "^4.0.0"
+    "purescript-debug": "^4.0.0",
+    "purescript-affjax": "^9.0.0",
+    "purescript-argonaut": "^6.0.0"
   }
 }

--- a/examples/Components/Dropdown/Dropdown.purs
+++ b/examples/Components/Dropdown/Dropdown.purs
@@ -23,12 +23,13 @@ data ExtraMessage
   = SelectionChanged (Maybe String) (Maybe String)
 
 type Slot =
-  H.Slot S.Query' (S.Message ExtraMessage)
+  H.Slot S.Query' ExtraMessage
 
 spec :: S.Spec ExtraState (Const Void) Void () ExtraMessage Aff
 spec = S.defaultSpec 
   { render = render
-  , handleMessage = handleMessage 
+  -- pass H.raise here to simply re-raise regular Select messages
+  , handleMessage = handleMessage
   }
   where
   handleMessage = case _ of
@@ -36,7 +37,7 @@ spec = S.defaultSpec
       st <- H.get
       let selection = st.items !! ix
       H.modify_ _ { selection = selection }
-      H.raise $ S.Message $ SelectionChanged st.selection selection
+      H.raise $ SelectionChanged st.selection selection
     _ -> pure unit
 
   render st = HH.div_ [ renderToggle, renderMenu ]

--- a/examples/Components/Dropdown/Dropdown.purs
+++ b/examples/Components/Dropdown/Dropdown.purs
@@ -6,7 +6,7 @@ import Data.Const (Const)
 import Effect.Aff.Class (class MonadAff)
 import Data.Array ((!!), mapWithIndex)
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Tuple (Tuple(..))
+import Data.Monoid (guard)
 import Docs.CSS as CSS
 import Halogen as H
 import Halogen.HTML as HH
@@ -14,118 +14,52 @@ import Halogen.HTML.Properties as HP
 import Select as Select
 import Select.Setters as Setters
 
-{-
-  There is no longer any need to write a new component to wrap Select. Instead, you can
-  extend Select's state, input, query algebra (and by extension, actions), messages, and 
-  child components. Rather than create a wrapping component, simply use Select with  
-  your extensions in place!
-
-  This module exports a version of Select extended to be a proper dropdown. It renders
-  a button and maintains the current selection from the list.
--}
-
------
--- Component
-
--- The types used to define this component are below; all we have to do is specialize
--- the type of the component for convenient exporting. 
--- 
--- It's trivial to swap out the render function, query handler, or message handler
--- for another, thereby building an entirely different component. In this case, we'll 
--- provide a render function and a handleMessage function, but use `pure Nothing` for 
--- our query handler as we don't need to extend the query algebra in any way.
-spec :: forall m. MonadAff m => Select.Spec ExtraState (Const Void) () ExtraMessage m 
-spec = Select.defaultSpec { render = render, handleMessage = handleMessage }
-
------
--- State
-
--- Select does not by default have any conception of 'selected' items, but we can 
--- extend its state to include a `selection` field which maintains the index of the 
--- selected item.
 type ExtraState =
   ( items :: Array String
   , selection :: Maybe String 
   )
 
--- We can create a new type synonym that extends Select's state with this new field.
-type State = Select.State ExtraState
-
--- We can do the same for the Input type if we want. We'll get the new fields in 
--- state via the input, so the parameter shows up here, too.
-type Input = Select.Input ExtraState
-
-
------
--- Message
-
--- We'll notify parent components when the selection has changed. We'll tell the parent
--- about the old state and the new state.
 data ExtraMessage
-  = SelectionChanged (Tuple (Maybe String) (Maybe String))
+  = SelectionChanged (Maybe String) (Maybe String)
 
-type Message = Select.Message ExtraMessage
+type Slot =
+  H.Slot Select.Query' (Select.Message ExtraMessage)
 
--- Sometimes you may need to take some action when a message is emitted. For example,
--- there are several ways an item can be selected in `Select` and you may want to
--- perform some action or query after this event has occurred. In these cases, you
--- can provide a handler for Select to manage these messages for itself in addition
--- to raising them to a parent.
-handleMessage :: forall m. Message -> H.HalogenM State Action () Message m Unit
-handleMessage = case _ of
-  -- We want to take action when an item has been selected, so let's handle that.
-  Select.Selected ix -> do
-    st <- H.get
-    let selection = st.items !! ix
-    H.modify_ _ { selection = selection }
-    H.raise $ Select.Raised $ SelectionChanged $ Tuple st.selection selection
-  _ -> 
-    pure unit
-
------
--- Query
-
--- We're able to introduce all the new behavior we need via the `handleMessage` 
--- function, so we don't need to introduce any new queries to Select. However, you
--- can freely extend the query algebra (and, by extension, the actions) new queries 
--- so long as you also provide a handler for them.
-
-type Query = Select.Query'
-type Action = Select.Action ExtraState (Const Void) ()
-
------
--- Render Function
-
-render :: forall m. State -> H.ComponentHTML Action () m
-render state = HH.div_ [ renderToggle, renderMenu ]
+spec :: forall m. MonadAff m => Select.Spec ExtraState (Const Void) () ExtraMessage m 
+spec = Select.defaultSpec 
+  { render = render
+  , handleMessage = handleMessage 
+  }
   where
-  renderToggle =
-    HH.button
-      ( Setters.setToggleProps state [ HP.classes CSS.button ] )
-      [ HH.text $ fromMaybe "Select an option" state.selection ]
+  handleMessage = case _ of
+    Select.Selected ix -> do
+      st <- H.get
+      let selection = st.items !! ix
+      H.modify_ _ { selection = selection }
+      H.raise $ Select.Raised $ SelectionChanged st.selection selection
+    _ -> pure unit
 
-  renderMenu =
-    HH.div [ HP.classes CSS.menu ]
-      if state.visibility == Select.Off
-        then []
-        else [ renderContainer $ renderItem `mapWithIndex` state.items ]
+  render state = HH.div_ [ renderToggle, renderMenu ]
     where
-    renderContainer html =
-      HH.div
-        ( Setters.setContainerProps [ HP.classes CSS.itemContainer ] )
-        [ HH.ul [ HP.classes CSS.ul ] html ]
+    renderToggle =
+      HH.button
+        ( Setters.setToggleProps state [ HP.classes CSS.button ] )
+        [ HH.text $ fromMaybe "Select an option" state.selection ]
 
-    renderItem index item =
-      HH.li
-        ( Setters.setItemProps index props )
-        [ HH.text item ]
+    renderMenu =
+      HH.div 
+        [ HP.classes CSS.menu ]
+        ([ renderContainer $ renderItem `mapWithIndex` state.items ] # guard (state.visibility == Select.Off))
       where
-      props =
-        [ HP.classes
-          ( CSS.li <>
-            if state.highlightedIndex == Just index
-              then [ HH.ClassName "bg-grey-lighter" ]
-              else []
-          )
-        ]
+      renderContainer html =
+        HH.div
+          ( Setters.setContainerProps [ HP.classes CSS.itemContainer ] )
+          [ HH.ul [ HP.classes CSS.ul ] html ]
+
+      renderItem index item =
+        HH.li
+          ( Setters.setItemProps index [ HP.class_ bgClass ] )
+          [ HH.text item ]
+        where
+        bgClass = HH.ClassName $ "bg-grey-lighter" # guard (state.highlightedIndex == Just index)
 

--- a/examples/Components/Dropdown/Dropdown.purs
+++ b/examples/Components/Dropdown/Dropdown.purs
@@ -57,9 +57,6 @@ spec = Select.defaultSpec
           [ HH.ul [ HP.classes CSS.ul ] html ]
 
       renderItem index item =
-        HH.li
-          ( Setters.setItemProps index [ HP.class_ bgClass ] )
-          [ HH.text item ]
+        HH.li (Setters.setItemProps index [ HP.class_ bgClass ]) [ HH.text item ]
         where
         bgClass = HH.ClassName $ "bg-grey-lighter" # guard (state.highlightedIndex == Just index)
-

--- a/examples/Components/Dropdown/Dropdown.purs
+++ b/examples/Components/Dropdown/Dropdown.purs
@@ -3,7 +3,7 @@ module Docs.Components.Dropdown where
 import Prelude
 
 import Data.Const (Const)
-import Effect.Aff.Class (class MonadAff)
+import Effect.Aff (Aff)
 import Data.Array ((!!), mapWithIndex)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Monoid (guard)
@@ -11,8 +11,8 @@ import Docs.CSS as CSS
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-import Select as Select
-import Select.Setters as Setters
+import Select as S
+import Select.Setters as SS
 
 type ExtraState =
   ( items :: Array String
@@ -23,40 +23,46 @@ data ExtraMessage
   = SelectionChanged (Maybe String) (Maybe String)
 
 type Slot =
-  H.Slot Select.Query' (Select.Message ExtraMessage)
+  H.Slot S.Query' (S.Message ExtraMessage)
 
-spec :: forall m. MonadAff m => Select.Spec ExtraState (Const Void) () ExtraMessage m 
-spec = Select.defaultSpec 
+spec :: S.Spec ExtraState (Const Void) Void () ExtraMessage Aff
+spec = S.defaultSpec 
   { render = render
   , handleMessage = handleMessage 
   }
   where
   handleMessage = case _ of
-    Select.Selected ix -> do
+    S.Selected ix -> do
       st <- H.get
       let selection = st.items !! ix
       H.modify_ _ { selection = selection }
-      H.raise $ Select.Raised $ SelectionChanged st.selection selection
+      H.raise $ S.Message $ SelectionChanged st.selection selection
     _ -> pure unit
 
-  render state = HH.div_ [ renderToggle, renderMenu ]
+  render st = HH.div_ [ renderToggle, renderMenu ]
     where
     renderToggle =
       HH.button
-        ( Setters.setToggleProps state [ HP.classes CSS.button ] )
-        [ HH.text $ fromMaybe "Select an option" state.selection ]
+        ( SS.setToggleProps st [ HP.classes CSS.button ] )
+        [ HH.text $ fromMaybe "Select an option" st.selection ]
 
     renderMenu =
       HH.div 
         [ HP.classes CSS.menu ]
-        ([ renderContainer $ renderItem `mapWithIndex` state.items ] # guard (state.visibility == Select.Off))
+        ([ renderContainer renderItems ] # guard (st.visibility == S.Off))
       where
       renderContainer html =
         HH.div
-          ( Setters.setContainerProps [ HP.classes CSS.itemContainer ] )
+          ( SS.setContainerProps [ HP.classes CSS.itemContainer ] )
           [ HH.ul [ HP.classes CSS.ul ] html ]
 
+      renderItems =
+        renderItem `mapWithIndex` st.items
+
       renderItem index item =
-        HH.li (Setters.setItemProps index [ HP.class_ bgClass ]) [ HH.text item ]
+        HH.li 
+          (SS.setItemProps index [ HP.class_ (HH.ClassName bgClass) ]) 
+          [ HH.text item ]
         where
-        bgClass = HH.ClassName $ "bg-grey-lighter" # guard (state.highlightedIndex == Just index)
+        bgClass = "bg-grey-lighter" # guard (st.highlightedIndex == Just index)
+

--- a/examples/Components/Typeahead/Typeahead.purs
+++ b/examples/Components/Typeahead/Typeahead.purs
@@ -39,7 +39,7 @@ type ChildSlots =
   ( dropdown :: DD.Slot Unit )
 
 type Slot = 
-  H.Slot (Select.Query ExtraQuery ChildSlots) (Select.Message ExtraMessage)
+  Select.Slot ExtraQuery ChildSlots ExtraMessage
 
 spec :: forall m. MonadAff m => Select.Spec ExtraState ExtraQuery ChildSlots ExtraMessage m
 spec = Select.defaultSpec 

--- a/examples/Components/Typeahead/Typeahead.purs
+++ b/examples/Components/Typeahead/Typeahead.purs
@@ -2,15 +2,21 @@ module Docs.Components.Typeahead where
 
 import Prelude
 
-import Data.Array (elemIndex, mapWithIndex, difference, filter, (:))
+import Affjax as AX
+import Affjax.ResponseFormat as AR
+import Data.Argonaut.Decode ((.:), decodeJson)
+import Data.Array (mapWithIndex, filter, (:), (!!))
 import Data.Foldable (for_, length)
-import Data.Maybe (Maybe(..))
+import Data.Bifunctor (lmap)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Monoid (guard)
-import Data.String (Pattern(..), contains)
 import Data.Symbol (SProxy(..))
+import Data.Traversable (traverse)
+import Data.Tuple (Tuple(..))
 import Docs.CSS as CSS
+import Docs.Internal.RemoteData as RD
 import Docs.Components.Dropdown as Dropdown
-import Effect.Aff.Class (class MonadAff)
+import Effect.Aff.Class (class MonadAff, liftAff)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -18,48 +24,33 @@ import Halogen.HTML.Properties as HP
 import Select as Select
 import Select.Setters as Setters
 
-{-
-  You can make complex selection interfaces like typeaheads the same way you can
-  make simpler ones like dropdowns. It just comes down to how much of Select you
-  want to extend.
-
-  In this case, we'll extend the component so that it can manage a list of selections,
-  where no selected item should be displayed in the list of available options. We'll
-  need to extend the component state with the list of selections; we'll need to extend
-  the query algebra with the ability to click to remove items; and we'll go ahead and
-  add a new message that lets a parent component know when an item was removed.
-
-  Plus, we'll get fancy: we'll have a dropdown running *inside* Select, using our
-  previous work.
--}
-
 -----
--- Component
+-- Spec
 
 -- Just like the dropdown, all we have to do to export a full component is just 
 -- specialize the types and supply a render function, query handler, and message 
 -- handler.
-component :: forall m. MonadAff m => H.Component HH.HTML Query Input Message m
-component = Select.component render handleQuery handleMessage
-
+spec :: forall m. MonadAff m => Select.Spec ExtraState ExtraQuery ChildSlots ExtraMessage m
+spec = Select.defaultSpec 
+  { render = render
+  , handleQuery = handleQuery
+  , handleMessage = handleMessage
+  }
 
 -----
 -- State
 
--- Select doesn't maintain any selections on its own, but we can extend it to 
--- hold a list of selected items by adding new contents to state. We'll need
--- three lists: a list of all items, a list of non-selected items, and a list
--- of selected items.
-type State = Select.State String ExtraState
-
+-- Our typeahead will fetch its data remotely, which means that we won't maintain
+-- a list of items in state. We'll represent our items as remote data which may be 
+-- present but may also be loading or in an error state.
 type ExtraState =
-  ( selectedItems :: Array String
-  , visibleItems :: Array String
+  ( selections :: Array Location 
+  , available :: RD.RemoteData String (Array Location)
   )
 
--- Our input type will also need these items
-type Input = Select.Input String ExtraState
-
+-- Our state and input types can now be extended with these
+type State = Select.State ExtraState
+type Input = Select.Input ExtraState
 
 -----
 -- Child Components
@@ -71,17 +62,16 @@ type ChildSlots =
 
 _dropdown = SProxy :: SProxy "dropdown"
 
-
 -----
 -- Messages
 
 -- We'll add a new message to Select to cover the case when an item is removed. The
 -- parent might wish to display a confirmation of the last-removed item or use it
 -- otherwise.
-type Message = Select.Message String ExtraMessage
-
 data ExtraMessage 
-  = ItemRemoved String 
+  = ItemRemoved Location 
+
+type Message = Select.Message ExtraMessage
 
 -- We also need to take action when an item is selected in Select or a debounced
 -- search has completed. We'll do that by handling the message within Select.
@@ -91,27 +81,29 @@ handleMessage
   => Message 
   -> H.HalogenM State Action ChildSlots Message m Unit
 handleMessage = case _ of
-  Select.Selected item -> do
+  Select.Selected ix -> do
     st <- H.get
-    let newSelections = item : st.selectedItems
-    H.modify_ _ 
-      { selectedItems = newSelections
-      , visibleItems = difference newSelections st.items
-      , search = ""
-      }
+    case st.available of 
+      RD.Success arr -> do
+        let newSelections = fromMaybe st.selections $ (_ : st.selections) <$> (arr !! ix)
+        H.modify_ _ { selections = newSelections, search = "" } 
+      _ -> pure unit
   
   Select.Searched str -> do
     st <- H.get
-    let 
-      visible = difference st.selectedItems $ filter (contains (Pattern str)) st.items
-      index = elemIndex str visible
-    H.modify_ _ { visibleItems = visible }
-    for_ index \ix -> do
-      Select.handleAction handleQuery handleMessage $ Select.Highlight $ Select.Index ix
+
+    -- we'll use an external api to search locations 
+    H.modify_ _ { available = RD.Loading }
+    items <- searchLocations str
+    H.modify_ _ { available = items, lastIndex = maybe 0 (\arr -> length arr - 1) $ RD.toMaybe items }
+
+    -- and then highlight the first one
+    handleAction $ Select.Highlight $ Select.Index 0
   
   _ -> 
     pure unit
-
+  where
+  handleAction act = Select.handleAction handleQuery handleMessage act
 
 
 -----
@@ -120,13 +112,13 @@ handleMessage = case _ of
 -- We introduced some new behavior for selecting items via the `handleMessage` function
 -- but we also need to support removal and we need to handle messages output by our
 -- further child component, the dropdown.
-type Query = Select.Query String ExtraQuery ChildSlots
+type Query = Select.Query ExtraQuery ChildSlots
 
 -- We'll provide a synonym for the action type, too.
-type Action = Select.Action String ExtraQuery ChildSlots
+type Action = Select.Action ExtraState ExtraQuery ChildSlots
 
 data ExtraQuery a
-  = Remove String a
+  = Remove Location a
   | HandleDropdown Dropdown.Message a
 
 handleQuery 
@@ -137,25 +129,23 @@ handleQuery
 handleQuery = case _ of  
   Remove item a -> Just a <$ do
     st <- H.get
-    let newSelections = filter (_ /= item) st.selectedItems
-    H.modify_ _
-      { selectedItems = newSelections
-      , visibleItems = difference newSelections st.items
-      }
+    let newSelections = filter (_ /= item) st.selections
+    H.modify_ _ { selections = newSelections }
     H.raise $ Select.Raised $ ItemRemoved item
   
-  -- We can handle our child component
+  -- We can also handle our child component
   HandleDropdown msg a -> Just a <$ case msg of
-    Select.Selected item -> do
+    Select.Raised (Dropdown.SelectionChanged (Tuple oldSelection newSelection)) -> do
       st <- H.get
-      let index = elemIndex item st.items
-      for_ index \ix -> 
-        -- Remember that we're handling this from the typeahead; calling
-        -- the below will cause the *typeahead* to select the item, not the
-        -- dropdown.
-        Select.handleAction handleQuery handleMessage 
-          $ Select.Select (Select.Index ix) Nothing
-
+      let 
+	mkLocation str = { name: "User Added: " <> str, population: "1" }
+        newSelections = case oldSelection, newSelection of
+          Nothing, Nothing -> Nothing
+	  Nothing, Just str -> Just (mkLocation str : st.selections)
+          Just str, Nothing -> Just (filter (_ /= mkLocation str) st.selections)
+          Just old, Just new -> Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
+      for_ newSelections \selections -> 
+        H.modify_ _ { selections = selections }
     _ -> 
       pure unit
 
@@ -168,7 +158,7 @@ render state =
     [ renderSelections, renderInput, renderContainer ]
   where
   renderSelections :: forall props. HH.HTML props Action
-  renderSelections = case length state.selectedItems of
+  renderSelections = case length state.selections of
     0 -> 
       HH.div_ []
     _ ->
@@ -176,20 +166,19 @@ render state =
         [ class_ "bg-white rounded-sm w-full border-b border-grey-lighter" ]
         [ HH.ul
           [ class_ "list-reset" ]
-          (renderSelectedItem <$> state.selectedItems)
+          (renderSelectedItem <$> state.selections)
         ]
     where
     renderSelectedItem item =
       HH.li
         [ class_ "px-4 py-1 text-grey-darkest hover:bg-grey-lighter relative" ]
-        [ HH.span_ [ HH.text item ]
+        [ renderLocation item
         , closeButton item
         ]
 
     closeButton item =
       HH.span
-        [ HE.onClick \_ -> 
-            Just $ Select.AsAction $ Select.Embed $ Remove item unit
+        [ HE.onClick \_ -> Just $ Select.AsAction $ Select.Embed $ H.tell $ Remove item
         , class_ "absolute pin-t pin-b pin-r p-1 mx-3 cursor-pointer" 
         ]
         [ HH.text "×" ]
@@ -202,37 +191,43 @@ render state =
   renderContainer =
     HH.div 
       [ class_ "relative z-50" ]
-      if state.visibility == Select.Off
-        then []
-        else [ renderItems $ renderItem `mapWithIndex` state.visibleItems ]
+      ([ renderItems (mapWithIndex renderItem) ] # guard (state.visibility == Select.On))
     where
     -- here we can render a further child component, the dropdown, which is *also*
     -- a select component.
-    renderChild = HH.slot _dropdown unit Dropdown.component input handleChild
+    renderChild = HH.slot _dropdown unit (Select.component Dropdown.spec) input handleChild
       where
       handleChild msg = Just (Select.AsAction (Select.Embed (H.tell (HandleDropdown msg))))
-
       input = 
         { inputType: Select.Toggle
-	, items: [ "Choice A", "Choice B" ]
 	, search: Nothing
 	, debounceTime: Nothing
+        , lastIndex: 1
+
+        -- extensions
+	, items: [ "Earth", "Mars" ]
 	, selection: Nothing
 	}
 
-    renderItems html =
+    renderItems f = do
+      let renderMsg msg = [ HH.span [ class_ "pa-4" ] [ HH.text msg ] ]
       HH.div
         ( Setters.setContainerProps
           [ class_ "absolute bg-white shadow rounded-sm pin-t pin-l w-full" ]
         )
-        [ HH.ul 
-            [ class_ "list-reset" ] 
-            html 
-        , renderChild
-        ]
+	case state.available of
+            RD.NotAsked -> renderMsg "No search performed..."
+	    RD.Loading -> renderMsg "Loading..."
+            RD.Failure e -> renderMsg e
+	    RD.Success available -> 
+	     [ HH.ul 
+                 [ class_ "list-reset" ] 
+                 (f available) 
+             , renderChild
+	     ]
 
     renderItem index item =
-      HH.li (Setters.setItemProps index [ class_ (base <> extra) ]) [ HH.text item ]
+      HH.li (Setters.setItemProps index [ class_ (base <> extra) ]) [ renderLocation item ]
       where
       base = "px-4 py-1 text-grey-darkest"
       extra = " bg-grey-lighter" # guard (state.highlightedIndex == Just index) 
@@ -243,4 +238,31 @@ render state =
 
 class_ :: ∀ p i. String -> HH.IProp ( "class" :: String | i ) p
 class_ = HP.class_ <<< HH.ClassName
+
+-----
+-- Async
+
+type Location =
+  { name :: String
+  , population :: String
+  }
+
+renderLocation :: forall t0 t1. Location -> HH.HTML t0 t1
+renderLocation { name, population } = 
+  HH.div_
+    [ HH.text name
+    , HH.span
+        [ class_ "ml-4 text-grey-lighter" ]
+	[ HH.text population ]
+    ]
+
+searchLocations 
+  :: forall m
+   . MonadAff m
+  => String
+  -> m (RD.RemoteData String (Array Location))
+searchLocations search = liftAff do
+  res <- AX.get AR.json ("https://swapi.co/api/planets/?search=" <> search) 
+  let body = lmap AR.printResponseFormatError res.body
+  pure $ RD.fromEither $ traverse decodeJson =<< (_ .: "results") =<< decodeJson =<< body
 

--- a/examples/Components/Typeahead/Typeahead.purs
+++ b/examples/Components/Typeahead/Typeahead.purs
@@ -8,7 +8,7 @@ import Data.Argonaut.Decode ((.:), decodeJson)
 import Data.Array (mapWithIndex, filter, (:), (!!))
 import Data.Foldable (for_, length)
 import Data.Bifunctor (lmap)
-import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Monoid (guard)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse)
@@ -100,6 +100,7 @@ spec = S.defaultSpec
         for_ newSelections \selections -> 
           H.modify_ _ { selections = selections }
 
+  render :: S.State ExtraState -> H.ComponentHTML (S.Action ExtraAction) ChildSlots Aff
   render state = HH.div_ [ renderSelections, renderInput, renderContainer ]
     where
     renderSelections = case length state.selections of

--- a/examples/Components/Typeahead/Typeahead.purs
+++ b/examples/Components/Typeahead/Typeahead.purs
@@ -12,10 +12,9 @@ import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Monoid (guard)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse)
-import Data.Tuple (Tuple(..))
 import Docs.CSS as CSS
 import Docs.Internal.RemoteData as RD
-import Docs.Components.Dropdown as Dropdown
+import Docs.Components.Dropdown as DD
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Halogen as H
 import Halogen.HTML as HH
@@ -24,223 +23,160 @@ import Halogen.HTML.Properties as HP
 import Select as Select
 import Select.Setters as Setters
 
------
--- Spec
+type ExtraState =
+  ( selections :: Array Location 
+  , available :: RD.RemoteData String (Array Location)
+  )
 
--- Just like the dropdown, all we have to do to export a full component is just 
--- specialize the types and supply a render function, query handler, and message 
--- handler.
+data ExtraQuery a
+  = Remove Location a
+  | HandleDropdown (Select.Message DD.ExtraMessage) a
+
+data ExtraMessage 
+  = ItemRemoved Location 
+
+type ChildSlots = 
+  ( dropdown :: DD.Slot Unit )
+
+type Slot = 
+  H.Slot (Select.Query ExtraQuery ChildSlots) (Select.Message ExtraMessage)
+
 spec :: forall m. MonadAff m => Select.Spec ExtraState ExtraQuery ChildSlots ExtraMessage m
 spec = Select.defaultSpec 
   { render = render
   , handleQuery = handleQuery
   , handleMessage = handleMessage
   }
-
------
--- State
-
--- Our typeahead will fetch its data remotely, which means that we won't maintain
--- a list of items in state. We'll represent our items as remote data which may be 
--- present but may also be loading or in an error state.
-type ExtraState =
-  ( selections :: Array Location 
-  , available :: RD.RemoteData String (Array Location)
-  )
-
--- Our state and input types can now be extended with these
-type State = Select.State ExtraState
-type Input = Select.Input ExtraState
-
------
--- Child Components
-
--- We're going to embed a dropdown in the component, so we'll extend Select with
--- new child slots.
-type ChildSlots = 
-  ( dropdown :: H.Slot Dropdown.Query Dropdown.Message Unit )
-
-_dropdown = SProxy :: SProxy "dropdown"
-
------
--- Messages
-
--- We'll add a new message to Select to cover the case when an item is removed. The
--- parent might wish to display a confirmation of the last-removed item or use it
--- otherwise.
-data ExtraMessage 
-  = ItemRemoved Location 
-
-type Message = Select.Message ExtraMessage
-
--- We also need to take action when an item is selected in Select or a debounced
--- search has completed. We'll do that by handling the message within Select.
-handleMessage 
-  :: forall m
-   . MonadAff m
-  => Message 
-  -> H.HalogenM State Action ChildSlots Message m Unit
-handleMessage = case _ of
-  Select.Selected ix -> do
-    st <- H.get
-    case st.available of 
-      RD.Success arr -> do
-        let newSelections = fromMaybe st.selections $ (_ : st.selections) <$> (arr !! ix)
-        H.modify_ _ { selections = newSelections, search = "" } 
-      _ -> pure unit
-  
-  Select.Searched str -> do
-    st <- H.get
-
-    -- we'll use an external api to search locations 
-    H.modify_ _ { available = RD.Loading }
-    items <- searchLocations str
-    H.modify_ _ { available = items, lastIndex = maybe 0 (\arr -> length arr - 1) $ RD.toMaybe items }
-
-    -- and then highlight the first one
-    handleAction $ Select.Highlight $ Select.Index 0
-  
-  _ -> 
-    pure unit
   where
-  handleAction act = Select.handleAction handleQuery handleMessage act
-
-
------
--- Query
-
--- We introduced some new behavior for selecting items via the `handleMessage` function
--- but we also need to support removal and we need to handle messages output by our
--- further child component, the dropdown.
-type Query = Select.Query ExtraQuery ChildSlots
-
--- We'll provide a synonym for the action type, too.
-type Action = Select.Action ExtraState ExtraQuery ChildSlots
-
-data ExtraQuery a
-  = Remove Location a
-  | HandleDropdown Dropdown.Message a
-
-handleQuery 
-  :: forall m a
-   . MonadAff m
-  => ExtraQuery a
-  -> H.HalogenM State Action ChildSlots Message m (Maybe a)
-handleQuery = case _ of  
-  Remove item a -> Just a <$ do
-    st <- H.get
-    let newSelections = filter (_ /= item) st.selections
-    H.modify_ _ { selections = newSelections }
-    H.raise $ Select.Raised $ ItemRemoved item
-  
-  -- We can also handle our child component
-  HandleDropdown msg a -> Just a <$ case msg of
-    Select.Raised (Dropdown.SelectionChanged (Tuple oldSelection newSelection)) -> do
+  handleMessage = case _ of
+    Select.Selected ix -> do
       st <- H.get
-      let 
-	mkLocation str = { name: "User Added: " <> str, population: "1" }
-        newSelections = case oldSelection, newSelection of
-          Nothing, Nothing -> Nothing
-	  Nothing, Just str -> Just (mkLocation str : st.selections)
-          Just str, Nothing -> Just (filter (_ /= mkLocation str) st.selections)
-          Just old, Just new -> Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
-      for_ newSelections \selections -> 
-        H.modify_ _ { selections = selections }
+      case st.available of 
+        RD.Success arr -> do
+          let newSelections = fromMaybe st.selections $ (_ : st.selections) <$> (arr !! ix)
+          H.modify_ _ { selections = newSelections, search = "" } 
+        _ -> pure unit
+  
+    Select.Searched str -> do
+      st <- H.get
+
+      -- we'll use an external api to search locations 
+      H.modify_ _ { available = RD.Loading }
+      items <- searchLocations str
+      H.modify_ _ { available = items, lastIndex = maybe 0 (\arr -> length arr - 1) $ RD.toMaybe items }
+
+      -- and then highlight the first one
+      handleAction $ Select.Highlight $ Select.Index 0
+  
     _ -> 
       pure unit
-
------
--- Render Function
-
-render :: forall m. MonadAff m => State -> H.ComponentHTML Action ChildSlots m
-render state = 
-  HH.div_ 
-    [ renderSelections, renderInput, renderContainer ]
-  where
-  renderSelections :: forall props. HH.HTML props Action
-  renderSelections = case length state.selections of
-    0 -> 
-      HH.div_ []
-    _ ->
-      HH.div
-        [ class_ "bg-white rounded-sm w-full border-b border-grey-lighter" ]
-        [ HH.ul
-          [ class_ "list-reset" ]
-          (renderSelectedItem <$> state.selections)
-        ]
     where
-    renderSelectedItem item =
-      HH.li
-        [ class_ "px-4 py-1 text-grey-darkest hover:bg-grey-lighter relative" ]
-        [ renderLocation item
-        , closeButton item
-        ]
+    handleAction act = Select.handleAction handleQuery handleMessage act
 
-    closeButton item =
-      HH.span
-        [ HE.onClick \_ -> Just $ Select.AsAction $ Select.Embed $ H.tell $ Remove item
-        , class_ "absolute pin-t pin-b pin-r p-1 mx-3 cursor-pointer" 
-        ]
-        [ HH.text "×" ]
+  handleQuery :: forall a. ExtraQuery a -> H.HalogenM _ _ _ _ _ (Maybe a)
+  handleQuery = case _ of  
+    Remove item a -> Just a <$ do
+      st <- H.get
+      let newSelections = filter (_ /= item) st.selections
+      H.modify_ _ { selections = newSelections }
+      H.raise $ Select.Raised $ ItemRemoved item
   
-  renderInput = HH.input $ Setters.setInputProps
-    [ HP.classes CSS.input
-    , HP.placeholder "Type to search..." 
-    ]
+    -- We can also handle our child component
+    HandleDropdown msg a -> Just a <$ case msg of
+      Select.Raised (DD.SelectionChanged oldSelection newSelection) -> do
+        st <- H.get
+        let 
+          mkLocation str = { name: "User Added: " <> str, population: "1" }
+          newSelections = case oldSelection, newSelection of
+            Nothing, Nothing -> Nothing
+            Nothing, Just str -> Just (mkLocation str : st.selections)
+            Just str, Nothing -> Just (filter (_ /= mkLocation str) st.selections)
+            Just old, Just new -> Just (mkLocation new : (filter (_ /= mkLocation old) st.selections))
+        for_ newSelections \selections -> 
+          H.modify_ _ { selections = selections }
+      _ -> 
+        pure unit
 
-  renderContainer =
-    HH.div 
-      [ class_ "relative z-50" ]
-      ([ renderItems (mapWithIndex renderItem) ] # guard (state.visibility == Select.On))
+  render state = HH.div_ [ renderSelections, renderInput, renderContainer ]
     where
-    -- here we can render a further child component, the dropdown, which is *also*
-    -- a select component.
-    renderChild = HH.slot _dropdown unit (Select.component Dropdown.spec) input handleChild
+    renderSelections = case length state.selections of
+      0 -> 
+        HH.div_ []
+      _ ->
+        HH.div
+          [ class_ "bg-white rounded-sm w-full border-b border-grey-lighter" ]
+          [ HH.ul
+            [ class_ "list-reset" ]
+            (renderSelectedItem <$> state.selections)
+          ]
       where
-      handleChild msg = Just (Select.AsAction (Select.Embed (H.tell (HandleDropdown msg))))
-      input = 
-        { inputType: Select.Toggle
-	, search: Nothing
-	, debounceTime: Nothing
-        , lastIndex: 1
+      renderSelectedItem item =
+        HH.li
+          [ class_ "px-4 py-1 text-grey-darkest hover:bg-grey-lighter relative" ]
+          [ renderLocation item
+          , closeButton item
+          ]
 
-        -- extensions
-	, items: [ "Earth", "Mars" ]
-	, selection: Nothing
-	}
+      closeButton item =
+        HH.span
+          [ HE.onClick \_ -> Just $ Select.AsAction $ Select.Embed $ H.tell $ Remove item
+          , class_ "absolute pin-t pin-b pin-r p-1 mx-3 cursor-pointer" 
+          ]
+          [ HH.text "×" ]
 
-    renderItems f = do
-      let renderMsg msg = [ HH.span [ class_ "pa-4" ] [ HH.text msg ] ]
-      HH.div
-        ( Setters.setContainerProps
-          [ class_ "absolute bg-white shadow rounded-sm pin-t pin-l w-full" ]
-        )
-	case state.available of
+    renderInput = HH.input $ Setters.setInputProps
+      [ HP.classes CSS.input
+      , HP.placeholder "Type to search..." 
+      ]
+
+    renderContainer =
+      HH.div 
+        [ class_ "relative z-50" ]
+        ([ renderItems (mapWithIndex renderItem) ] # guard (state.visibility == Select.On))
+      where
+      -- here we can render a further child component, the dropdown, which is *also*
+      -- a select component.
+      renderChild = HH.slot _dropdown unit (Select.component DD.spec) input handleChild
+        where
+        _dropdown = SProxy :: SProxy "dropdown"
+        handleChild msg = Just (Select.AsAction (Select.Embed (H.tell (HandleDropdown msg))))
+        input = 
+          { inputType: Select.Toggle
+          , search: Nothing
+          , debounceTime: Nothing
+          , lastIndex: 1
+	  , items: [ "Earth", "Mars" ]
+	  , selection: Nothing
+          }
+
+      renderItems f = do
+        let renderMsg msg = [ HH.span [ class_ "pa-4" ] [ HH.text msg ] ]
+        HH.div
+          ( Setters.setContainerProps
+            [ class_ "absolute bg-white shadow rounded-sm pin-t pin-l w-full" ]
+          )
+          case state.available of
             RD.NotAsked -> renderMsg "No search performed..."
-	    RD.Loading -> renderMsg "Loading..."
+            RD.Loading -> renderMsg "Loading..."
             RD.Failure e -> renderMsg e
-	    RD.Success available -> 
+            RD.Success available -> 
 	     [ HH.ul 
                  [ class_ "list-reset" ] 
                  (f available) 
              , renderChild
 	     ]
 
-    renderItem index item =
-      HH.li (Setters.setItemProps index [ class_ (base <> extra) ]) [ renderLocation item ]
-      where
-      base = "px-4 py-1 text-grey-darkest"
-      extra = " bg-grey-lighter" # guard (state.highlightedIndex == Just index) 
-
+      renderItem index item =
+        HH.li (Setters.setItemProps index [ class_ (base <> extra) ]) [ renderLocation item ]
+        where
+        base = "px-4 py-1 text-grey-darkest"
+        extra = " bg-grey-lighter" # guard (state.highlightedIndex == Just index) 
 
 -----
 -- Helpers
 
 class_ :: ∀ p i. String -> HH.IProp ( "class" :: String | i ) p
 class_ = HP.class_ <<< HH.ClassName
-
------
--- Async
 
 type Location =
   { name :: String
@@ -256,11 +192,7 @@ renderLocation { name, population } =
 	[ HH.text population ]
     ]
 
-searchLocations 
-  :: forall m
-   . MonadAff m
-  => String
-  -> m (RD.RemoteData String (Array Location))
+searchLocations :: forall m. MonadAff m => String -> m (RD.RemoteData String (Array Location))
 searchLocations search = liftAff do
   res <- AX.get AR.json ("https://swapi.co/api/planets/?search=" <> search) 
   let body = lmap AR.printResponseFormatError res.body

--- a/examples/Internal/RemoteData.purs
+++ b/examples/Internal/RemoteData.purs
@@ -1,0 +1,43 @@
+-- | Copied over from 
+-- | https://github.com/krisajenkins/purescript-remotedata
+-- |
+-- | due to dependency conflicts
+module Docs.Internal.RemoteData where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+
+-- | A datatype representing fetched data.
+-- |
+-- | If you find yourself continually using `Maybe (Either e a)` to
+-- | represent data loaded from an external source, or you have a
+-- | habit of shuffling errors away to where they can be quietly
+-- | ignored, consider using this. It makes it easier to represent the
+-- | real state of a remote data fetch and handle it properly.
+data RemoteData e a
+  = NotAsked
+  | Loading
+  | Failure e
+  | Success a
+
+derive instance eqRemoteData :: (Eq e, Eq a) => Eq (RemoteData e a)
+
+derive instance functorRemoteData :: Functor (RemoteData e)
+
+-- | Convert a `RemoteData` to a `Maybe`.
+toMaybe :: forall e a. RemoteData e a -> Maybe a
+toMaybe (Success value) = Just value
+toMaybe _ = Nothing
+
+-- | Convert a `Maybe` to `RemoteData`.
+fromMaybe :: forall e a. Maybe a -> RemoteData e a
+fromMaybe Nothing = NotAsked
+fromMaybe (Just value) = Success value
+
+-- | Convert an `Either` to `RemoteData`
+fromEither :: forall e a. Either e a -> RemoteData e a
+fromEither (Left err) = Failure err
+fromEither (Right value) = Success value
+

--- a/examples/Internal/RemoteData.purs
+++ b/examples/Internal/RemoteData.purs
@@ -8,14 +8,9 @@ import Prelude
 
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
+import Data.Foldable (class Foldable, foldrDefault, foldlDefault)
 
 -- | A datatype representing fetched data.
--- |
--- | If you find yourself continually using `Maybe (Either e a)` to
--- | represent data loaded from an external source, or you have a
--- | habit of shuffling errors away to where they can be quietly
--- | ignored, consider using this. It makes it easier to represent the
--- | real state of a remote data fetch and handle it properly.
 data RemoteData e a
   = NotAsked
   | Loading
@@ -23,8 +18,15 @@ data RemoteData e a
   | Success a
 
 derive instance eqRemoteData :: (Eq e, Eq a) => Eq (RemoteData e a)
-
 derive instance functorRemoteData :: Functor (RemoteData e)
+
+instance foldableRemoteData :: Foldable (RemoteData e) where
+  foldMap f (Success a) = f a
+  foldMap _ (Failure e) = mempty
+  foldMap _ NotAsked = mempty
+  foldMap _ Loading = mempty
+  foldr f = foldrDefault f
+  foldl f = foldlDefault f
 
 -- | Convert a `RemoteData` to a `Maybe`.
 toMaybe :: forall e a. RemoteData e a -> Maybe a

--- a/examples/Main.purs
+++ b/examples/Main.purs
@@ -2,16 +2,16 @@ module Main where
 
 import Prelude
 
-import Data.Array (zipWith)
+import Data.Array (zipWith, length)
 import Data.Const (Const)
 import Data.Map as M
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (for_, sequence, traverse)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
 import Docs.Internal.Proxy (ProxyS, proxy)
-import Docs.Internal.RemoteData (RemoteData(..))
+import Docs.Internal.RemoteData (RemoteData(..), toMaybe)
 import Docs.Components.Typeahead as Typeahead
 import Docs.Components.Dropdown as Dropdown
 import Effect (Effect)
@@ -99,8 +99,7 @@ dropdown = H.mkComponent
     { inputType: Select.Toggle
     , debounceTime: Nothing
     , search: Nothing
-    , lastIndex: 2
-    , watchInput: false
+    , getItemCount: length <<< _.items
     , items: [ "one", "two", "three" ]
     , selection: Nothing
     }
@@ -118,8 +117,7 @@ typeahead = H.mkComponent
     { inputType: Select.Text
     , debounceTime: Just (Milliseconds 300.0)
     , search: Nothing
-    , watchInput: false
-    , lastIndex: 0
+    , getItemCount: maybe 0 length <<< toMaybe <<< _.available
     , selections: mempty
     , available: NotAsked
     }

--- a/examples/Main.purs
+++ b/examples/Main.purs
@@ -99,8 +99,6 @@ dropdown = H.mkComponent
     , debounceTime: Nothing
     , search: Nothing
     , lastIndex: 2
-
-    -- extension
     , items: [ "one", "two", "three" ]
     , selection: Nothing
     }
@@ -118,9 +116,6 @@ typeahead = H.mkComponent
     , debounceTime: Just (Milliseconds 300.0)
     , search: Nothing
     , lastIndex: 0
-
-    -- extension
     , selections: mempty
     , available: NotAsked
     }
-

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "watch": "pulp -w build",
     "build-docs": "pulp build -I examples --to docs/js/app.js",
     "watch-docs": "pulp -w --then 'mkdocs serve' build -I examples --to docs/js/app.js",
-    "clean": "rm -rf output bower_components node_modules site docs/js",
+    "clean": "rm -rf output bower_components site docs/js",
     "postinstall": "bower i --silent"
   },
   "devDependencies": {

--- a/src/Select.purs
+++ b/src/Select.purs
@@ -29,9 +29,6 @@ import Web.HTML.HTMLElement as HTMLElement
 import Web.UIEvent.KeyboardEvent as KE
 import Web.UIEvent.MouseEvent as ME
 
------
--- ACTIONS
-
 data Action st query ps
   = Search String
   | Highlight Target
@@ -46,7 +43,7 @@ data Action st query ps
   | Receive (Input st)
   | AsAction (Query query ps Unit)
 
-type Action' = Action () (Const Void) ()
+type Action' st = Action st (Const Void) ()
 
 -----
 -- QUERIES
@@ -127,8 +124,6 @@ type State st =
   | st
   }
 
-type State' = State ()
-
 type Debouncer =
   { var :: AVar Unit
   , fiber :: Fiber Unit
@@ -142,8 +137,6 @@ type Input st =
   | st
   }
 
-type Input' = Input ()
-
 type Spec st query ps msg m =
   { render :: State st -> H.ComponentHTML (Action st query ps) ps m
   , handleQuery :: forall a. query a -> H.HalogenM (State st) (Action st query ps) ps (Message msg) m (Maybe a)
@@ -151,6 +144,8 @@ type Spec st query ps msg m =
   , initialize :: Maybe (Action st query ps)
   , receive :: Input st -> Maybe (Action st query ps)
   }
+
+type Spec' st m = Spec st (Const Void) () Void m
 
 defaultSpec :: forall st query ps msg m. Spec st query ps msg m
 defaultSpec = 

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -37,10 +37,10 @@ type ToggleProps props =
 -- | renderToggle = div (setToggleProps [ class "btn-class" ]) [ ...html ]
 -- | ```
 setToggleProps
-  :: forall props st query ps
+  :: forall props st act
    . State st
-  -> Array (HP.IProp (ToggleProps props) (Action st query ps))
-  -> Array (HP.IProp (ToggleProps props) (Action st query ps))
+  -> Array (HP.IProp (ToggleProps props) (Action st act))
+  -> Array (HP.IProp (ToggleProps props) (Action st act))
 setToggleProps st = append
   [ HE.onFocus \_ -> Just $ SetVisibility On
   , HE.onMouseDown $ Just <<< ToggleClick
@@ -72,9 +72,9 @@ type InputProps props =
 -- | renderInput = input_ (setInputProps [ class "my-class" ])
 -- | ```
 setInputProps
-  :: forall st props query ps
-   . Array (HP.IProp (InputProps props) (Action st query ps))
-  -> Array (HP.IProp (InputProps props) (Action st query ps))
+  :: forall props st act
+   . Array (HP.IProp (InputProps props) (Action st act))
+  -> Array (HP.IProp (InputProps props) (Action st act))
 setInputProps = append
   [ HE.onFocus \_ -> Just $ SetVisibility On
   , HE.onKeyDown $ Just <<< Key
@@ -106,10 +106,10 @@ type ItemProps props =
 -- | render = renderItem `mapWithIndex` itemsArray
 -- | ```
 setItemProps
-  :: forall st props query ps
+  :: forall props st act
    . Int 
-  -> Array (HP.IProp (ItemProps props) (Action st query ps)) 
-  -> Array (HP.IProp (ItemProps props) (Action st query ps))
+  -> Array (HP.IProp (ItemProps props) (Action st act)) 
+  -> Array (HP.IProp (ItemProps props) (Action st act))
 setItemProps index = append
   [ HE.onMouseDown \ev -> Just (Select (Index index) (Just ev))
   , HE.onMouseOver \_ -> Just $ Highlight (Index index)
@@ -120,8 +120,9 @@ setItemProps index = append
 -- | from bubbling up a blur event to the DOM. This should be used on the parent
 -- | element that contains your items.
 setContainerProps
-  :: forall st props query ps
-   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st query ps))
-  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st query ps))
+  :: forall props st act
+   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st act))
+  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st act))
 setContainerProps = append
   [ HE.onMouseDown $ Just <<< PreventClick ]
+

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -39,8 +39,8 @@ type ToggleProps props =
 setToggleProps
   :: forall props st act
    . State st
-  -> Array (HP.IProp (ToggleProps props) (Action st act))
-  -> Array (HP.IProp (ToggleProps props) (Action st act))
+  -> Array (HP.IProp (ToggleProps props) (Action act))
+  -> Array (HP.IProp (ToggleProps props) (Action act))
 setToggleProps st = append
   [ HE.onFocus \_ -> Just $ SetVisibility On
   , HE.onMouseDown $ Just <<< ToggleClick
@@ -72,9 +72,9 @@ type InputProps props =
 -- | renderInput = input_ (setInputProps [ class "my-class" ])
 -- | ```
 setInputProps
-  :: forall props st act
-   . Array (HP.IProp (InputProps props) (Action st act))
-  -> Array (HP.IProp (InputProps props) (Action st act))
+  :: forall props act
+   . Array (HP.IProp (InputProps props) (Action act))
+  -> Array (HP.IProp (InputProps props) (Action act))
 setInputProps = append
   [ HE.onFocus \_ -> Just $ SetVisibility On
   , HE.onKeyDown $ Just <<< Key
@@ -107,10 +107,10 @@ type ItemProps props =
 -- | render = renderItem `mapWithIndex` itemsArray
 -- | ```
 setItemProps
-  :: forall props st act
+  :: forall props act
    . Int 
-  -> Array (HP.IProp (ItemProps props) (Action st act)) 
-  -> Array (HP.IProp (ItemProps props) (Action st act))
+  -> Array (HP.IProp (ItemProps props) (Action act)) 
+  -> Array (HP.IProp (ItemProps props) (Action act))
 setItemProps index = append
   [ HE.onMouseDown \ev -> Just (Select (Index index) (Just ev))
   , HE.onMouseOver \_ -> Just $ Highlight (Index index)
@@ -121,9 +121,9 @@ setItemProps index = append
 -- | from bubbling up a blur event to the DOM. This should be used on the parent
 -- | element that contains your items.
 setContainerProps
-  :: forall props st act
-   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st act))
-  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st act))
+  :: forall props act
+   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action act))
+  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action act))
 setContainerProps = append
   [ HE.onMouseDown $ Just <<< PreventClick ]
 

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -37,10 +37,10 @@ type ToggleProps props =
 -- | renderToggle = div (setToggleProps [ class "btn-class" ]) [ ...html ]
 -- | ```
 setToggleProps
-  :: forall props item st query ps
-   . State item st
-  -> Array (HP.IProp (ToggleProps props) (Action item query ps))
-  -> Array (HP.IProp (ToggleProps props) (Action item query ps))
+  :: forall props st query ps
+   . State st
+  -> Array (HP.IProp (ToggleProps props) (Action st query ps))
+  -> Array (HP.IProp (ToggleProps props) (Action st query ps))
 setToggleProps st = append
   [ HE.onFocus \_ -> Just $ SetVisibility On
   , HE.onMouseDown $ Just <<< ToggleClick
@@ -72,9 +72,9 @@ type InputProps props =
 -- | renderInput = input_ (setInputProps [ class "my-class" ])
 -- | ```
 setInputProps
-  :: forall props item query ps
-   . Array (HP.IProp (InputProps props) (Action item query ps))
-  -> Array (HP.IProp (InputProps props) (Action item query ps))
+  :: forall st props query ps
+   . Array (HP.IProp (InputProps props) (Action st query ps))
+  -> Array (HP.IProp (InputProps props) (Action st query ps))
 setInputProps = append
   [ HE.onFocus \_ -> Just $ SetVisibility On
   , HE.onKeyDown $ Just <<< Key
@@ -106,10 +106,10 @@ type ItemProps props =
 -- | render = renderItem `mapWithIndex` itemsArray
 -- | ```
 setItemProps
-  :: forall props item query ps
+  :: forall st props query ps
    . Int 
-  -> Array (HP.IProp (ItemProps props) (Action item query ps)) 
-  -> Array (HP.IProp (ItemProps props) (Action item query ps))
+  -> Array (HP.IProp (ItemProps props) (Action st query ps)) 
+  -> Array (HP.IProp (ItemProps props) (Action st query ps))
 setItemProps index = append
   [ HE.onMouseDown \ev -> Just (Select (Index index) (Just ev))
   , HE.onMouseOver \_ -> Just $ Highlight (Index index)
@@ -120,8 +120,8 @@ setItemProps index = append
 -- | from bubbling up a blur event to the DOM. This should be used on the parent
 -- | element that contains your items.
 setContainerProps
-  :: forall props item query ps
-   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action item query ps))
-  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action item query ps))
+  :: forall st props query ps
+   . Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st query ps))
+  -> Array (HP.IProp (onMouseDown :: ME.MouseEvent | props) (Action st query ps))
 setContainerProps = append
   [ HE.onMouseDown $ Just <<< PreventClick ]

--- a/src/Select/Setters.purs
+++ b/src/Select/Setters.purs
@@ -11,7 +11,7 @@ import Halogen as H
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Select
-import Web.Event.Event (Event)
+import Web.Event.Event as E
 import Web.UIEvent.FocusEvent as FE
 import Web.UIEvent.KeyboardEvent as KE
 import Web.UIEvent.MouseEvent as ME
@@ -55,7 +55,7 @@ setToggleProps st = append
 type InputProps props =
   ( onFocus :: FE.FocusEvent
   , onKeyDown :: KE.KeyboardEvent
-  , onInput :: Event
+  , onInput :: E.Event
   , value :: String
   , onMouseDown :: ME.MouseEvent
   , onBlur :: FE.FocusEvent
@@ -101,7 +101,8 @@ type ItemProps props =
 -- | with `mapWithIndex`:
 -- |
 -- | ```purescript
--- | renderItem index itemHTML = HH.li (setItemProps index [ class "my-class" ]) [ itemHTML ]
+-- | renderItem index itemHTML = 
+-- |   HH.li (setItemProps index [ props ]) [ itemHTML ]
 -- |
 -- | render = renderItem `mapWithIndex` itemsArray
 -- | ```


### PR DESCRIPTION
## What does this pull request do?

I was working on upgrading Formless to Halogen 5 and realized that dropdowns / typeaheads that use anything other than an array to represent available items for selection will still need a wrapping parent component rather than just be extensible. The `item` type is used in the Selected message and to calculate the last index of the container. The last index calculation is done only when the list of available items is changed.

It turns out that it's quite easy to remove the `item` type altogether and simply require the end user to pass in their items as an extension to the component. Their items can be a prefix tree, a `RemoteData`, an array, whatever they see fit. They already have to pass in their selections as an extension, so having them pass in both is barely any more trouble than passing in just one. And since you always had to manage changes to the number of items in the available items array in the parent it's not much trouble to ask for the item count when it is passed to the component.

Therefore we're able to introduce even quite a bit more flexibility to the component with (imo) no impact on usability.

I also introduced a new type: `Spec`. This type allows users to choose a render function, handleQuery function, handleMessage function, and initializer to extend Select with. It works like Halogen's `eval` in the sense that we provide a `defaultSpec` that can be overridden. If you only need a render function, you'd do `spec = Select.defaultSpec { render = render }`. 

This type cuts down on the number of type synonyms necessary to export one of these extended components. Rather than have synonyms for state, query, message, etc. you just define your extensions and provide them to the `Spec` type and to the `Slot` type you want to export from the module.

A consumer can then do:

```purescript
type ChildSlots = ( dropdown :: Dropdown.Slot Unit )

_dropdown = SProxy :: SProxy "dropdown"

render = ...
  HH.slot _dropdown unit (Select.component Dropdown.spec) input handler
```

In other words, you'd now think of exporting various "specs" that can be used with the Select component. I could also extend this spec with a `finalizer` so you can override Select's default one with one of your own.

### Other changes

- I removed a bunch of comments as they're better suited to the documentation site.
- I removed the `HeytingAlgebra` for visibility temporarily because it's soooo much code just to get `not`; I can put it back later
- I added an async typeahead to demonstrate that you really can extend it with arbitrary data types for the selections

## Drawbacks

The main drawback to the new approach is that you must remember to update the `lastIndex` value when you change the items available in the component. That was previously done with the `ReplaceItems` query which, to be honest, was quite clunky, or by having the items watch the parent's items in state for changes, which was actually buggy -- the last index would not change when the items changed, so Select was broken in that regard.

## Where should the reviewer start?

I'd recommend looking at the code not in diff form first, and then return to the diff, as the volume of comments makes this diff quite noisy.
